### PR TITLE
Fix png problems

### DIFF
--- a/components/CodeMirrorWrapper.js
+++ b/components/CodeMirrorWrapper.js
@@ -1,18 +1,9 @@
-import { forwardRef , lazy, Suspense} from 'react'
-const LazyCodeMirror = lazy(() =>
-    import('react-codemirror2').then((module) => ({
-      default: module.Controlled,
-    }))
-  );
-
-const CodeMirrorWrapper = forwardRef(function CodeMirrorWrapper(props, ref) {
-    if (typeof document === 'undefined') {
-        return <></>
-    }
-
-    return (<Suspense fallback={<div>Loading...</div>}>
-        <LazyCodeMirror {...props} ref={ref} />
-    </Suspense>)
-});
-
+let CodeMirrorWrapper
+if (typeof document === 'undefined') {
+  // server context, loading codemirror will cause error, so return a dummy component
+  CodeMirrorWrapper = () => <></>
+} else {
+  // client context, load the component with require, so it is synchronous
+  CodeMirrorWrapper = require('react-codemirror2').Controlled
+}
 export default CodeMirrorWrapper

--- a/components/Editor.js
+++ b/components/Editor.js
@@ -34,7 +34,6 @@ import {
 } from '../lib/constants'
 import { getRouteState } from '../lib/routing'
 import { getSettings, unescapeHtml, formatCode, omit } from '../lib/util'
-import domtoimage from '../lib/dom-to-image'
 import { nodeToSvg } from '../lib/svg'
 import { nodeToPng } from '../lib/png'
 
@@ -154,8 +153,7 @@ class Editor extends React.Component {
     }
     // alert('format is blob')
     // Twitter and Imgur needs regular dataURLs
-    //TODO: fix this!
-    return domtoimage.toPng(node, config)
+    return nodeToPng(node, config) // untested because the twitter thingy doesn't work locally bit it should work
   }
 
   tweet = () => {

--- a/components/Editor.js
+++ b/components/Editor.js
@@ -36,6 +36,7 @@ import { getRouteState } from '../lib/routing'
 import { getSettings, unescapeHtml, formatCode, omit } from '../lib/util'
 import domtoimage from '../lib/dom-to-image'
 import { nodeToSvg } from '../lib/svg'
+import { nodeToPng } from '../lib/png'
 
 const languageIcon = <LanguageIcon />
 
@@ -138,34 +139,19 @@ class Editor extends React.Component {
 
     if (format === 'svg') {
       return nodeToSvg(node, config)
-        .then(dataURL =>
-          dataURL
-            .replace(/&nbsp;/g, '&#160;')
-            // https://github.com/tsayen/dom-to-image/blob/fae625bce0970b3a039671ea7f338d05ecb3d0e8/src/dom-to-image.js#L551
-            .replace(/%23/g, '#')
-            .replace(/%0A/g, '\n')
-            // https://stackoverflow.com/questions/7604436/xmlparseentityref-no-name-warnings-while-loading-xml-into-a-php-file
-            .replace(/&(?!#?[a-z0-9]+;)/g, '&amp;')
-            // remove other fonts which are not used
-            .replace(
-              // current font-family used
-              new RegExp(
-                `@font-face\\s*{\\s*font-family:\\s*["']?(?!${this.state.fontFamily})[^'"]*?["']?.*?src:\\s*url\\(['"][^'"]*?base64[^'"]*?['"]\\);[^}]*}`,
-                'g'
-              ),
-              ''
-            )
-        )
         .then(uri => uri.slice(uri.indexOf(',') + 1))
         .then(data => new Blob([data], { type: 'image/svg+xml' }))
         .catch(console.error)
     }
 
     if (format === 'blob') {
-      return domtoimage.toBlob(node, config)
+      return nodeToPng(node, config)
+        .then(url => fetch(url))
+        .then(res => res.blob())
     }
-
+    // alert('format is blob')
     // Twitter and Imgur needs regular dataURLs
+    //TODO: fix this!
     return domtoimage.toPng(node, config)
   }
 

--- a/components/Editor.js
+++ b/components/Editor.js
@@ -130,6 +130,9 @@ class Editor extends React.Component {
           if (className.includes('CodeMirror-measure')) {
             return false;
           }
+          if (className.includes('handler') && n.role === "separator") {
+            return false;
+          }
         }
         return true
       },

--- a/lib/fonts.js
+++ b/lib/fonts.js
@@ -1,3 +1,4 @@
+// font parsing based on https://github.com/tsayen/dom-to-image
 import { parse } from 'opentype.js';
 // eslint is bullshitting here. woff2-encoder/decompress is valid (see https://github.com/itskyedo/woff2-encoder)
 // eslint-disable-next-line import/no-unresolved

--- a/lib/png.js
+++ b/lib/png.js
@@ -1,0 +1,36 @@
+import { nodeToSvg } from "./svg"
+import { blobToDataURL } from "./util";
+export async function nodeToPng(node, config) {
+    const svgBlob = await nodeToSvg(node, config)
+        .then(uri => uri.slice(uri.indexOf(',') + 1))
+        .then(data => new Blob([data], { type: 'image/svg+xml' }))
+    const svgDataUri = await blobToDataURL(svgBlob);
+
+    // https://zooper.pages.dev/articles/how-to-convert-a-svg-to-png-using-canvas
+    const canvas = document.createElement('canvas')
+    const transformStyle = config.style.transform;
+    const scale = parseFloat(transformStyle.match(/scale\(([^)]+)\)/)[1]) // multiplyer!
+
+    const width = node.getBoundingClientRect().width * scale
+    const height = node.getBoundingClientRect().height * scale
+
+    canvas.width = width
+    canvas.height = height
+    await drawImgToCanvas(svgDataUri, canvas, scale)
+    const pngUrl = canvas.toDataURL('image/png')
+    return pngUrl
+}
+
+function drawImgToCanvas(imgUrl, canvas, scale = 1) {
+    return new Promise((resolve, reject) => {
+        const img = new Image()
+        img.onload = () => {
+            const ctx = canvas.getContext('2d')
+            ctx.scale(scale, scale)
+            ctx.drawImage(img, 0, 0)
+            resolve()
+        }
+        img.onerror = reject
+        img.src = imgUrl
+    })
+}

--- a/lib/util.js
+++ b/lib/util.js
@@ -94,3 +94,12 @@ export const formatCode = async code => {
 export const stringifyColor = obj => `rgba(${obj.rgb.r},${obj.rgb.g},${obj.rgb.b},${obj.rgb.a})`
 
 export const generateId = () => Math.random().toString(36).slice(2)
+
+export function blobToDataURL(blob) {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader()
+    reader.onload = () => resolve(reader.result)
+    reader.onerror = reject
+    reader.readAsDataURL(blob)
+  })
+}


### PR DESCRIPTION
made all the imports syncrhonous again for codemirror and added functionality to save pngs based on the already generated svgs. done because the previously used lib had problems with text wrapping.