### PR TITLE
Supported complete tranparancy in powerpoint

### DIFF
--- a/lib/svg.js
+++ b/lib/svg.js
@@ -139,7 +139,21 @@ export async function nodeToSvg(node, config) {
                     svg.appendChild(rectClone)
 
                 }
-                svg.appendChild(rect)
+                // if the rect color is transparent, we remove the rect
+                let isTransparent = false
+                if (rectStyle.backgroundColor === "transparent") {
+                    isTransparent
+                }
+                if (rectStyle.backgroundColor.startsWith('rgba')) {
+                    const colorParts = rectStyle.backgroundColor.split(',')
+                    const alphaPart = colorParts[3].replace(')', '').trim()
+                    if (alphaPart === '0') {
+                        isTransparent = true
+                    }
+                }
+                if (!isTransparent) {
+                    svg.appendChild(rect)
+                }
                 //console.log(rect)
             } else if (currentNode.tagName === "svg") {
                 const svgElement = currentNode.cloneNode(true)


### PR DESCRIPTION
When re opening a powerpointn with a svg that has transparency, the transparency is stripped. Solution => we don't include rects in the image that have a alpha of zero